### PR TITLE
Fix path to ipfs binary

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,2 +1,2 @@
 var path = require('path')
-module.exports = path.join(__dirname, "dist", "ipfs", "ipfs")
+module.exports = path.join(__dirname, "bin", "ipfs")


### PR DESCRIPTION
I may be mistaken here, but shouldn't this point to the location of where the ipfs binary lives?