### PR TITLE
fix: Remove symbolic link to local ipfs

### DIFF
--- a/bin/ipfs
+++ b/bin/ipfs
@@ -1,1 +1,0 @@
-/Users/imp/code/npm-go-ipfs/node_modules/go-ipfs-dep/go-ipfs/ipfs


### PR DESCRIPTION
Fixes #17 
Inclusion of symbolic link breaks builds downstream, such as aragon/aragon-cli#257