### PR TITLE
feat: cache and verify downloaded archive

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,19 @@
+name: test
+
+on:
+  push:
+    branches: [ main, master ]
+  pull_request:
+    branches: [ main, master ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-node@v1
+      with:
+        node-version: 15.x
+    - run: npm install
+    - run: npm run build --if-present
+    - run: npm test

--- a/README.md
+++ b/README.md
@@ -49,9 +49,13 @@ console.info('go-ipfs is installed at', path())
 
 An error will be thrown if the path to the binary cannot be resolved.
 
+### Caching
+
+Downloaded archives are placed in OS-specific cache directory which can be customized by setting `NPM_GO_IPFS_CACHE` in env.
+
 ## Development
 
-**Warning**: the file `bin/ipfs` is a placeholder, when downloading stuff, it gets replaced. so if you run `node install.js` it will then be dirty in the git repo. **Do not commit this file**, as then you would be commiting a big binary and publishing it to npm. (**TODO: add a pre-commit or pre-publish hook that warns about this**)
+**Warning**: the file `bin/ipfs` is a placeholder, when downloading stuff, it gets replaced. so if you run `node install.js` it will then be dirty in the git repo. **Do not commit this file**, as then you would be commiting a big binary and publishing it to npm. A pre-commit hook exists and should protect against this, but better safe than sorry.
 
 ### Publish a new version
 

--- a/package.json
+++ b/package.json
@@ -5,9 +5,11 @@
   "main": "src/index.js",
   "scripts": {
     "postinstall": "node src/post-install.js",
+    "restore-bin": "git restore --source=HEAD --staged --worktree -- bin/ipfs",
     "test": "tape test/*.js | tap-spec",
     "lint": "standard"
   },
+  "pre-commit": "restore-bin",
   "bin": {
     "ipfs": "bin/ipfs"
   },
@@ -28,15 +30,18 @@
   "devDependencies": {
     "execa": "^4.0.1",
     "fs-extra": "^9.0.0",
+    "pre-commit": "^1.2.2",
     "standard": "^13.1.0",
     "tap-spec": "^5.0.0",
     "tape": "^4.13.2",
     "tape-promise": "^4.0.0"
   },
   "dependencies": {
+    "cachedir": "^2.3.0",
     "go-platform": "^1.0.0",
+    "got": "^11.7.0",
     "gunzip-maybe": "^1.4.2",
-    "node-fetch": "^2.6.0",
+    "hasha": "^5.2.2",
     "pkg-conf": "^3.1.0",
     "tar-fs": "^2.1.0",
     "unzip-stream": "^0.3.0"

--- a/test/fixtures/example-project/package.json
+++ b/test/fixtures/example-project/package.json
@@ -7,8 +7,5 @@
   "license": "ISC",
   "dependencies": {
     "go-ipfs": "file://../../../"
-  },
-  "go-ipfs": {
-    "version": "v0.4.20"
   }
 }

--- a/test/install.js
+++ b/test/install.js
@@ -2,31 +2,43 @@ const fs = require('fs-extra')
 const path = require('path')
 const test = require('tape')
 const execa = require('execa')
+const cachedir = require('cachedir')
 
 /*
-  Test that go-ipfs is downloaded during npm install.
-  - package up the current source code with `npm pack`
-  - install the tarball into the example project
-  - ensure that the "go-ipfs.version" prop in the package.json is used
+  Test that correct go-ipfs is downloaded during npm install.
 */
 
-const testVersion = require('./fixtures/example-project/package.json')['go-ipfs'].version
+const expectedVersion = require('../package.json').version
 
 async function clean () {
   await fs.remove(path.join(__dirname, 'fixtures', 'example-project', 'node_modules'))
   await fs.remove(path.join(__dirname, 'fixtures', 'example-project', 'package-lock.json'))
+  await fs.remove(cachedir('npm-go-ipfs'))
 }
 
 test.onFinish(clean)
 
-test('Ensure go-ipfs.version defined in parent package.json is used', async (t) => {
+test('Ensure go-ipfs defined in package.json is fetched on dependency install', async (t) => {
   await clean()
+
+  const exampleProjectRoot = path.join(__dirname, 'fixtures', 'example-project')
 
   // from `example-project`, install the module
   const res = execa.sync('npm', ['install'], {
-    cwd: path.join(__dirname, 'fixtures', 'example-project')
+    cwd: exampleProjectRoot
   })
-  const msg = `Downloading https://dist.ipfs.io/go-ipfs/${testVersion}`
-  t.ok(res.stdout.includes(msg), msg)
+
+  // confirm package.json is correct
+  const fetchedVersion = require(path.join(exampleProjectRoot, 'node_modules', 'go-ipfs', 'package.json')).version
+  t.ok(expectedVersion === fetchedVersion, `package.json versions match '${expectedVersion}'`)
+
+  // confirm binary is correct
+  const binary = path.join(exampleProjectRoot, 'node_modules', 'go-ipfs', 'bin', 'ipfs')
+  const versionRes = execa.sync(binary, ['--version'], {
+    cwd: exampleProjectRoot
+  })
+
+  t.ok(versionRes.stdout === `ipfs version ${expectedVersion}`, `ipfs --version output match '${expectedVersion}'`)
+
   t.end()
 })


### PR DESCRIPTION
This PR saves us time on CI and gives more confidence that downloaded archive is valid:

- :recycle: retries twice before failing to download (replaced `node-fetch` with `got`)
- :card_file_box:  adds caching of downloaded archives 
  - right now go-ipfs download slows down each build of ipfs-desktop
  - `electron`, `electron-builder` and [even our own `aegir`](https://github.com/ipfs/aegir/blob/0fb42b9046166806bb3f9f0ff6ecff048410a6d3/src/utils.js#L157-L168) already do this type of caching for big third-party downloads
  - faster install and CI will provide additional incentive for people to migrate from `go-ipfs-dep` (https://github.com/ipfs/npm-go-ipfs-dep/issues/45) 
- :stop_sign: adds pre-commit hook to protect against commiting real binary to git
- :detective: downloads `.sha512` manifest and compares it with sha512 of downloaded archive


### Demo: caching and verifying in action

First time downloads archive to the cache:

```
Downloading https://dist.ipfs.io/go-ipfs/v0.7.0/go-ipfs_v0.7.0_linux-amd64.tar.gz to /home/lidel/.cache/npm-go-ipfs
Downloaded https://dist.ipfs.io/go-ipfs/v0.7.0/go-ipfs_v0.7.0_linux-amd64.tar.gz
Downloading go-ipfs_v0.7.0_linux-amd64.tar.gz.sha512
Downloaded go-ipfs_v0.7.0_linux-amd64.tar.gz.sha512
Verifying go-ipfs_v0.7.0_linux-amd64.tar.gz.sha512
OK (1d5910f27e8d7ea333145f15c6edcbacc1e8db3a99365f0847467bdfa7c73f4d7a05562e46be8e932056c8324ed0769ca1b6758dfb0ac4c2e1b6066b57c4a086)
Unpacked /home/lidel/project/ipfs/npm-go-ipfs
Linking /home/lidel/project/ipfs/npm-go-ipfs/go-ipfs/ipfs to /home/lidel/project/ipfs/npm-go-ipfs/bin/ipfs
```

Second time reused archive from the cache:

```
https://dist.ipfs.io/go-ipfs/versions
Found /home/lidel/.cache/npm-go-ipfs/go-ipfs_v0.7.0_linux-amd64.tar.gz
Verifying go-ipfs_v0.7.0_linux-amd64.tar.gz.sha512
OK (1d5910f27e8d7ea333145f15c6edcbacc1e8db3a99365f0847467bdfa7c73f4d7a05562e46be8e932056c8324ed0769ca1b6758dfb0ac4c2e1b6066b57c4a086)
Unpacked /home/lidel/project/ipfs/npm-go-ipfs
Linking /home/lidel/project/ipfs/npm-go-ipfs/go-ipfs/ipfs to /home/lidel/project/ipfs/npm-go-ipfs/bin/ipfs
```

Note that SHA512 is compared on every run. 
If a single bit was flipped, it will return an error:

```
Found /home/lidel/.cache/npm-go-ipfs/go-ipfs_v0.7.0_linux-amd64.tar.gz
Verifying go-ipfs_v0.7.0_linux-amd64.tar.gz.sha512
Expected   SHA512: 2d5910f27e8d7ea333145f15c6edcbacc1e8db3a99365f0847467bdfa7c73f4d7a05562e46be8e932056c8324ed0769ca1b6758dfb0ac4c2e1b6066b57c4a086
Calculated SHA512: 1d5910f27e8d7ea333145f15c6edcbacc1e8db3a99365f0847467bdfa7c73f4d7a05562e46be8e932056c8324ed0769ca1b6758dfb0ac4c2e1b6066b57c4a086
Error: SHA512 of /home/lidel/.cache/npm-go-ipfs/go-ipfs_v0.7.0_linux-amd64.tar.gz' (1d5910f27e8d7ea333145f15c6edcbacc1e8db3a99365f0847467bdfa7c73f4d7a05562e46be8e932056c8324ed0769ca1b6758dfb0ac4c2e1b6066b57c4a086) does not match expected value from /home/lidel/.cache/npm-go-ipfs/go-ipfs_v0.7.0_linux-amd64.tar.gz.sha512 (2d5910f27e8d7ea333145f15c6edcbacc1e8db3a99365f0847467bdfa7c73f4d7a05562e46be8e932056c8324ed0769ca1b6758dfb0ac4c2e1b6066b57c4a086)
    at cachingFetchAndVerify (/home/lidel/project/ipfs/npm-go-ipfs/src/download.js:67:11)
```

cc @andrew