### PR TITLE
fix(ci): restore go-ipfs publishing to NPM

### DIFF
--- a/.github/actions/check-for-go-ipfs-release/Dockerfile
+++ b/.github/actions/check-for-go-ipfs-release/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:10
+FROM node:14
 
 LABEL "com.github.actions.name"="Update and publish"
 LABEL "com.github.actions.description"="Publish new version when a new go-ipfs version is relased"

--- a/.github/actions/publish/Dockerfile
+++ b/.github/actions/publish/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:10
+FROM node:14
 
 LABEL "com.github.actions.name"="Version and publish"
 LABEL "com.github.actions.description"="npm version and publish with new go-ipfs version"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,5 +1,6 @@
 name: Release to npm
 on:
+  workflow_dispatch:
   schedule:
     - cron: '0 * * * *'
 
@@ -16,7 +17,7 @@ jobs:
         if: steps.check.outputs.publish == 'true'
         uses: actions/setup-node@v1
         with:
-          node-version: 12
+          node-version: 14.x
       - name: Install
         if: steps.check.outputs.publish == 'true'
         run: npm install

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions/setup-node@v1
       with:
-        node-version: 15.x
+        node-version: 14.x
     - run: npm install
     - run: npm run build --if-present
     - run: npm test

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "src/index.js",
   "scripts": {
     "postinstall": "node src/post-install.js",
-    "restore-bin": "git restore --source=HEAD --staged --worktree -- bin/ipfs",
+    "restore-bin": "git reset -- bin/ipfs && git checkout -- bin/ipfs",
     "test": "tape test/*.js | tap-spec",
     "lint": "standard"
   },


### PR DESCRIPTION
This PR aims to fix NPM publishing.

It fails due to.. git binary being out of date?
https://github.com/ipfs/npm-go-ipfs/runs/2585452310?check_suite_focus=true

```
npm ERR! Command failed: git commit -m 0.9.0-rc1
npm ERR! git: 'restore' is not a git command. See 'git --help'.
```

- [x] Switch Node to LTS
   - Ensures package works with LTS +   15 would cause issue described in https://github.com/ipfs/npm-go-ipfs/issues/36
- [x] Fix use of   `git restore` in `package.json`  – github seems to have old `git` version