### PR TITLE
feat: add types

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,5 +15,6 @@ jobs:
       with:
         node-version: 14.x
     - run: npm install
+    - uses: gozala/typescript-error-reporter-action@v1.0.8
     - run: npm run build --if-present
     - run: npm test

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ logs
 # Dependency directory
 # https://www.npmjs.org/doc/misc/npm-faq.html#should-i-check-my-node_modules-folder-into-git
 node_modules
+dist
 
 # while testing npm5
 package-lock.json

--- a/package.json
+++ b/package.json
@@ -7,12 +7,23 @@
     "postinstall": "node src/post-install.js",
     "restore-bin": "git reset -- bin/ipfs && git checkout -- bin/ipfs",
     "test": "tape test/*.js | tap-spec",
-    "lint": "standard"
+    "lint": "tsc --noEmit && standard",
+    "prepublishOnly": "tsc"
   },
   "pre-commit": "restore-bin",
   "bin": {
     "ipfs": "bin/ipfs"
   },
+  "files": [
+    "bin",
+    "dist",
+    "src",
+    "test",
+    "LICENSE",
+    "package.json",
+    "README.md",
+    "tsconfig.json"
+  ],
   "repository": {
     "type": "git",
     "url": "git+https://github.com/ipfs/npm-go-ipfs.git"
@@ -27,14 +38,20 @@
     "url": "https://github.com/ipfs/npm-go-ipfs/issues"
   },
   "homepage": "https://github.com/ipfs/npm-go-ipfs",
+  "types": "./dist/src/types.d.ts",
   "devDependencies": {
+    "@types/got": "^9.6.12",
+    "@types/gunzip-maybe": "^1.4.0",
+    "@types/tar-fs": "^2.0.1",
+    "@types/unzip-stream": "^0.3.1",
     "execa": "^4.0.1",
     "fs-extra": "^9.0.0",
     "pre-commit": "^1.2.2",
     "standard": "^13.1.0",
     "tap-spec": "^5.0.0",
     "tape": "^4.13.2",
-    "tape-promise": "^4.0.0"
+    "tape-promise": "^4.0.0",
+    "typescript": "^4.3.5"
   },
   "dependencies": {
     "cachedir": "^2.3.0",

--- a/src/index.js
+++ b/src/index.js
@@ -15,5 +15,5 @@ module.exports.path = function () {
     }
   }
 
-  throw new Error('go-ipfs binary not found, it may not be installed or an error may have occured during installation')
+  throw new Error('go-ipfs binary not found, it may not be installed or an error may have occurred during installation')
 }

--- a/test/install.js
+++ b/test/install.js
@@ -24,7 +24,7 @@ test('Ensure go-ipfs defined in package.json is fetched on dependency install', 
   const exampleProjectRoot = path.join(__dirname, 'fixtures', 'example-project')
 
   // from `example-project`, install the module
-  const res = execa.sync('npm', ['install'], {
+  execa.sync('npm', ['install'], {
     cwd: exampleProjectRoot
   })
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,44 @@
+{
+  "compilerOptions": {
+    "strict": true,
+    // project options
+    "allowJs": true,
+    "checkJs": true,
+    "target": "ES2019",
+    "lib": [
+      "ES2019",
+      "ES2020.Promise",
+      "ES2020.String",
+      "ES2020.BigInt",
+      "DOM",
+      "DOM.Iterable"
+    ],
+    "noEmitOnError": true,
+    "incremental": true,
+    "composite": true,
+    "isolatedModules": true,
+    "removeComments": false,
+    // module resolution
+    "esModuleInterop": true,
+    "moduleResolution": "node",
+    // linter checks
+    "noImplicitReturns": false,
+    "noFallthroughCasesInSwitch": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": false,
+    // advanced
+    "importsNotUsedAsValues": "error",
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true,
+    "stripInternal": true,
+    "resolveJsonModule": true,
+    "outDir": "dist"
+  },
+  "include": [
+    "src",
+    "package.json"
+  ],
+  "exclude": [
+    "node_modules"
+  ]
+}


### PR DESCRIPTION
This module exports a `.path` function so add types to the module so we can use it without needing to add `@ts-ignore`s everywhere.