### PR TITLE
fix: remove go-platform dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,6 @@
   },
   "dependencies": {
     "cachedir": "^2.3.0",
-    "go-platform": "^1.0.0",
     "got": "^11.7.0",
     "gunzip-maybe": "^1.4.2",
     "hasha": "^5.2.2",

--- a/src/download.js
+++ b/src/download.js
@@ -14,7 +14,7 @@
     go-ipfs install path: './go-ipfs'
 */
 // @ts-ignore no types
-const goenv = require('go-platform')
+const goenv = require('./go-platform')
 const gunzip = require('gunzip-maybe')
 const got = require('got').default
 const path = require('path')

--- a/src/download.js
+++ b/src/download.js
@@ -13,7 +13,6 @@
     go-ipfs architecture: the architecture of the hardware this program is run from
     go-ipfs install path: './go-ipfs'
 */
-// @ts-ignore no types
 const goenv = require('./go-platform')
 const gunzip = require('gunzip-maybe')
 const got = require('got').default

--- a/src/go-platform.js
+++ b/src/go-platform.js
@@ -1,31 +1,33 @@
-const env = {}
+'use strict'
 
-switch (process.platform) {
-  case "darwin":
-  case "linux":
-  case "freebsd":
-    env.GOOS = process.platform
-    break
-  case "sunos":
-    env.GOOS = "solaris"
-    break
-  case "win32":
-    env.GOOS = "windows"
-    break
+function getGoOs () {
+  switch (process.platform) {
+    case "sunos":
+      return "solaris"
+    case "win32":
+      return "windows"
+  }
+
+  return process.platform
 }
 
-switch (process.arch) {
-  case "ia32":
-    env.GOARCH = "386"
-    break
-  case "x64":
-    env.GOARCH = "amd64"
-    break
-  case "arm":
-    env.GOARCH = "arm"
-  case "arm64":
-    env.GOARCH = "arm64"
-    break
+function getGoArch () {
+  switch (process.arch) {
+    case "ia32":
+      return "386"
+    case "x64":
+      return "amd64"
+    case "arm":
+      return "arm"
+    case "arm64":
+      return "arm64"
+  }
+
+  return process.arch
 }
 
-module.exports = env
+
+module.exports = {
+  GOOS: getGoOs(),
+  GOARCH: getGoArch()
+}

--- a/src/go-platform.js
+++ b/src/go-platform.js
@@ -1,0 +1,31 @@
+const env = {}
+
+switch (process.platform) {
+  case "darwin":
+  case "linux":
+  case "freebsd":
+    env.GOOS = process.platform
+    break
+  case "sunos":
+    env.GOOS = "solaris"
+    break
+  case "win32":
+    env.GOOS = "windows"
+    break
+}
+
+switch (process.arch) {
+  case "ia32":
+    env.GOARCH = "386"
+    break
+  case "x64":
+    env.GOARCH = "amd64"
+    break
+  case "arm":
+    env.GOARCH = "arm"
+  case "arm64":
+    env.GOARCH = "arm64"
+    break
+}
+
+module.exports = env


### PR DESCRIPTION
Remove `go-platform` npm dependency due to no longer maintain. Migrate it into `go-platform.js` and require it in `download.js`

Fixed issue: #40 