### PR TITLE
chore: Correct file to the generated types

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "url": "https://github.com/ipfs/npm-go-ipfs/issues"
   },
   "homepage": "https://github.com/ipfs/npm-go-ipfs",
-  "types": "./dist/src/types.d.ts",
+  "types": "./dist/src/index.d.ts",
   "devDependencies": {
     "@types/got": "^9.6.12",
     "@types/gunzip-maybe": "^1.4.0",


### PR DESCRIPTION
`dist` folder supposedly is part of NPM package artefact, so the only thing needed to provide TS declarations is to change the path.

Should solve #50 