### PR TITLE
fix: update path to TS types

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "url": "https://github.com/ipfs/npm-go-ipfs/issues"
   },
   "homepage": "https://github.com/ipfs/npm-go-ipfs",
-  "types": "./dist/src/types.d.ts",
+  "types": "./src/types.d.ts",
   "devDependencies": {
     "@types/got": "^9.6.12",
     "@types/gunzip-maybe": "^1.4.0",

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -1,0 +1,1 @@
+export function path(): string


### PR DESCRIPTION
Right now a link to TS declaration leads to a non-existing file.